### PR TITLE
Add CoffeeScript to list of other languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ String.dedent(pythonInterpreter)`
 
 ## In other languages
 
+- *CoffeeScript* - [block strings](https://coffeescript.org/#strings) using `'''` and `"""` triple-quotes.
 - *Java* - [text blocks](https://openjdk.java.net/jeps/378) using triple-quotes.
 - *Scala* - [multiline strings](https://docs.scala-lang.org/overviews/scala-book/two-notes-about-strings.html)
   using triple-quotes and `.stripMargin`.


### PR DESCRIPTION
In CoffeeScript, the example

```js
class MyClass {
  print() {
    console.log(`
      create table student(
        id int primary key,
        name text
      )
    `);
  }
}
```

would be written as

```coffee
class MyClass
  print: ->
    console.log '''
      create table student(
        id int primary key,
        name text
      )
    '''
```

and [works today](https://coffeescript.org/#try:class%20MyClass%0A%20%20print%3A%20-%3E%0A%20%20%20%20console.log%20'''%0A%20%20%20%20%20%20create%20table%20student(%0A%20%20%20%20%20%20%20%20id%20int%20primary%20key%2C%0A%20%20%20%20%20%20%20%20name%20text%0A%20%20%20%20%20%20)%0A%20%20%20%20''').

I didn’t see a structure to the list of languages so I added it first ;)