### PR TITLE
Fix missing variable "template" in String.dedent spec text.

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -44,6 +44,7 @@ markEffects: true
           1. Return ? Call(_tag_, _R_, _args_).
         1. Return CreateBuiltinFunction(_closure_, 1, *""*, &laquo; &raquo;).
       1. If ? IsArray(_templateOrFn_) is *true*, then
+        1. Let _template_ be _templateOrFn_.
         1. Let _dedented_ be ? DedentTemplateStringsArray(_template_).
         1. Return ? CookTemplateStringsArray(_dedented_, _substitutions_).
       1. Throw a *TypeError* exception.


### PR DESCRIPTION
I noticed that in String.dedent DedentTemplateStringsArray is called with `template`, but in this branch that name hasn't been defined. I thought the clearest solution would be to match the naming in the other branch and define template.